### PR TITLE
prepare 1.0.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run: sudo npm install -g react-native-cli
       - run: cd .. && git clone https://github.com/launchdarkly/hello-react-native.git
       - run: cd ../hello-react-native && npm install
-      - run: cp -r ../project/ ../hello-react-native/node_modules/launchdarkly-react-native-client/
+      - run: cp -r ../project/ ../hello-react-native/node_modules/launchdarkly-react-native-client-sdk/
       - run: circle-android wait-for-boot
       - run: 
           command: cd ../hello-react-native && react-native run-android
@@ -45,7 +45,7 @@ jobs:
       - run: sudo npm install -g react-native-cli
       - run: cd .. && git clone https://github.com/launchdarkly/hello-react-native.git
       - run: cd ../hello-react-native && npm install
-      - run: cp -r ../project/ ../hello-react-native/node_modules/launchdarkly-react-native-client/
+      - run: cp -r ../project/ ../hello-react-native/node_modules/launchdarkly-react-native-client-sdk/
       - run: cd ../hello-react-native && react-native run-ios --configuration Release
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
-# Change log
+# Changelog
 
 All notable changes to the LaunchDarkly React Native SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
+
+# Note on future releases
+
+The LaunchDarkly SDK repositories are being renamed for consistency. This repository is now `react-native-client-sdk` rather than `react-native-client`.
+
+The package name will also change. In the 1.0.0 release, it is still `launchdarkly-react-native-client`; in all future releases, it will be `launchdarkly-react-native-client-sdk`.
+
+## [1.0.0] - 2019-04-18
+### Changed
+- Android and iOS client versions
+### Fixed
+- Added correct anonymous property
+- Removed dependencies and added caret to peer dependencies
 
 ## [1.0.0-beta.1] - 2019-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The LaunchDarkly SDK repositories are being renamed for consistency. This reposi
 
 The package name will also change. In the 1.0.0 release, it is still `launchdarkly-react-native-client`; in all future releases, it will be `launchdarkly-react-native-client-sdk`.
 
+## [1.0.1] - 2019-05-03
+## Changed
+- Changed the package name from `launchdarkly-react-native-client` to `launchdarkly-react-native-client-sdk`
+- Changed repository references to use the new URL
+
+There are no other changes in this release. Substituting `launchdarkly-react-native-client` version 1.0.0 with `launchdarkly-react-native-client-sdk` version 1.0.1 will not affect functionality.
+
 ## [1.0.0] - 2019-04-18
 ### Changed
 - Android and iOS client versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,30 @@
-# How to work on this project
-1. Ensure you have `npm` and `react-native-cli` installed.
-2. Clone and setup the `hello-react-native` repo.
-3. Make changes in `node_modules/launchdarkly-react-native-client`.
-4. Test your changes in the root of Hello using either `react-native run-ios` or `react-native run-android`.
+Contributing to the LaunchDarkly Client-side SDK for React Native
+================================================
+ 
+LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/docs/sdk-contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
+ 
+Submitting bug reports and feature requests
+------------------
+ 
+The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/react-native-client-sdk/issues) in the SDK repository. Bug reports and feature requests specific to this SDK should be filed in this issue tracker. The SDK team will respond to all newly filed issues within two business days.
+ 
+Submitting pull requests
+------------------
+ 
+We encourage pull requests and other contributions from the community. Before submitting pull requests, ensure that all temporary or unintended code is removed. Don't worry about adding reviewers to the pull request; the LaunchDarkly SDK team will add themselves. The SDK team will acknowledge all pull requests within two business days.
+ 
+Build instructions
+------------------
+ 
+### Prerequisites
+ 
+This SDK requires that you have [`npm`](https://www.npmjs.com/) and [`react-native-cli`](https://www.npmjs.com/package/react-native-cli) installed in order to develop with it.
+ 
+### Building and running
+
+You can modify and verify changes by developing within the LaunchDarkly React Native SDK sample application (`hello-react-native`).
+
+1. In your `react-native-client-sdk` directory, run `npm link`.
+2. Clone and setup the [`hello-react-native`](https://github.com/launchdarkly/hello-react-native) repository.
+3. In your `hello-react-native` directory, run `npm link react-native-client-sdk`.
+4. Test your changes in `hello-react-native` by running either `react-native run-ios` or `react-native run-android` depending on your desired runtime environment.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,26 @@
+LaunchDarkly Client-side SDK for React Native
+===========================
 
-launchdarkly-react-native-client
-================================
+LaunchDarkly overview
+-------------------------
+[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/docs/getting-started) using LaunchDarkly today!
+
+[![Twitter Follow](https://img.shields.io/twitter/follow/launchdarkly.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/intent/follow?screen_name=launchdarkly)
+
+Supported versions
+-------------------------
+
+This SDK is compatible with React Native 0.57.7 and is tested in Android 27 and iOS 12.1.
 
 Getting started
 ---------------
 
-`$ npm install launchdarkly-react-native-client --save`
-
-Mostly automatic installation
------------------------------
-
-`$ react-native link launchdarkly-react-native-client`
-
-Usage
------
-
-```javascript
-import LDClient from 'launchdarkly-react-native-client';
-
-async componentDidMount() {
-    try {
-      let client = new LDClient();
-
-      let clientConfig =
-          { "mobileKey": "YOUR_MOBILE_KEY",
-            "stream": true,
-            "offline": false
-          };
-
-      let userConfig = { "key": "user_key" };
-
-      await client.configure(clientConfig, userConfig);
-      this.setState({ldClient: client});
-      let res = await this.state.ldClient.stringVariation("MY_STRING_FLAG_KEY", "");
-      Alert.alert('LD Server Response', String(res));
-    } catch(err) {
-      console.error(err);
-    }
-}
-```
+Refer to the [SDK documentation](https://docs.launchdarkly.com/docs/react-native-sdk-reference#section-getting-started) for instructions on getting started with using the SDK.
 
 Learn more
 -----------
 
-Check out our [documentation](http://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](http://docs.launchdarkly.com/docs/react-native-sdk-reference).
+Check out our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/docs/react-native-sdk-reference).
 
 Testing
 -------
@@ -53,7 +30,7 @@ We run integration tests for all our SDKs using a centralized test harness. This
 Contributing
 ------------
 
-We encourage pull-requests and other contributions from the community. We've also published an [SDK contributor's guide](http://docs.launchdarkly.com/docs/sdk-contributors-guide) that provides a detailed explanation of how our SDKs work.
+We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
 About LaunchDarkly
 -----------
@@ -63,21 +40,10 @@ About LaunchDarkly
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
     * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
-* LaunchDarkly provides feature flag SDKs for
-    * [Java](http://docs.launchdarkly.com/docs/java-sdk-reference "Java SDK")
-    * [JavaScript](http://docs.launchdarkly.com/docs/js-sdk-reference "LaunchDarkly JavaScript SDK")
-    * [PHP](http://docs.launchdarkly.com/docs/php-sdk-reference "LaunchDarkly PHP SDK")
-    * [Python](http://docs.launchdarkly.com/docs/python-sdk-reference "LaunchDarkly Python SDK")
-    * [Go](http://docs.launchdarkly.com/docs/go-sdk-reference "LaunchDarkly Go SDK")
-    * [Node.JS](http://docs.launchdarkly.com/docs/node-sdk-reference "LaunchDarkly Node SDK")
-    * [Electron](http://docs.launchdarkly.com/docs/electron-sdk-reference "LaunchDarkly Electron SDK")
-    * [.NET](http://docs.launchdarkly.com/docs/dotnet-sdk-reference "LaunchDarkly .Net SDK")
-    * [Ruby](http://docs.launchdarkly.com/docs/ruby-sdk-reference "LaunchDarkly Ruby SDK")
-    * [iOS](http://docs.launchdarkly.com/docs/ios-sdk-reference "LaunchDarkly iOS SDK")
-    * [Android](http://docs.launchdarkly.com/docs/android-sdk-reference "LaunchDarkly Android SDK")
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
 * Explore LaunchDarkly
-    * [launchdarkly.com](http://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
-    * [docs.launchdarkly.com](http://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDKs
-    * [apidocs.launchdarkly.com](http://apidocs.launchdarkly.com/  "LaunchDarkly API Documentation") for our API documentation
-    * [blog.launchdarkly.com](http://blog.launchdarkly.com/  "LaunchDarkly Blog Documentation") for the latest product updates
+    * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
+    * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides
+    * [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/  "LaunchDarkly API Documentation") for our API documentation
+    * [blog.launchdarkly.com](https://blog.launchdarkly.com/  "LaunchDarkly Blog Documentation") for the latest product updates
     * [Feature Flagging Guide](https://github.com/launchdarkly/featureflags/  "Feature Flagging Guide") for best practices and strategies

--- a/ios/LaunchdarklyReactNativeClient.podspec
+++ b/ios/LaunchdarklyReactNativeClient.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "LaunchdarklyReactNativeClient"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "LaunchdarklyReactNativeClient"
   s.description  = <<-DESC
                   LaunchdarklyReactNativeClient
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache-2.0", :file => "../LICENSE" }
   s.author       = { "author" => "support@launchdarkly.com" }
   s.platform     = :ios, "9.0"
-  s.source       = { :git => "https://github.com/launchdarkly/react-native-client.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/launchdarkly/react-native-client-sdk.git", :tag => "master" }
   s.source_files  = "**/*.{h,m,swift}"
   s.swift_version = "3.0"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "launchdarkly-react-native-client",
-  "version": "1.0.0",
+  "name": "launchdarkly-react-native-client-sdk",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/launchdarkly/react-native-client.git"
+    "url": "https://github.com/launchdarkly/react-native-client-sdk.git"
   },
   "keywords": [
     "react-native"
@@ -16,9 +16,9 @@
   "author": "LaunchDarkly",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/launchdarkly/react-native-client/issues"
+    "url": "https://github.com/launchdarkly/react-native-client-sdk/issues"
   },
-  "homepage": "https://docs.launchdarkly.com/v2.0/docs/react-native-sdk-reference",
+  "homepage": "https://docs.launchdarkly.com/docs/react-native-sdk-reference",
   "peerDependencies": {
     "react-native": "^0.57.7",
     "react": "^16.6.1"


### PR DESCRIPTION
## [1.0.1] - 2019-05-03
## Changed
- Changed the package name from `launchdarkly-react-native-client` to `launchdarkly-react-native-client-sdk`
- Changed repository references to use the new URL

There are no other changes in this release. Substituting `launchdarkly-react-native-client` version 1.0.0 with `launchdarkly-react-native-client-sdk` version 1.0.1 will not affect functionality.