### PR TITLE
fix(podspec): do not use optimistic SDK version

### DIFF
--- a/ios/LaunchdarklyReactNativeClient.podspec
+++ b/ios/LaunchdarklyReactNativeClient.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.swift_version = "3.0"
 
   s.dependency "React"
-  s.dependency "LaunchDarkly", "~> 3.0.0-beta.3"
+  s.dependency "LaunchDarkly", "3.0.0-beta.3"
 
 end


### PR DESCRIPTION
Follow up to https://github.com/launchdarkly/react-native-client-sdk/issues/7

This change would provide faster and more actionable feedback when using an incompatible version of the iOS SDK. `~> 3.0.0-beta.3` allows `3.0.0` and `3.0.1` to be installed, both of which are incompatible