### PR TITLE
skip tests in releaser

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -8,6 +8,8 @@ publications:
 
 template:
   name: npm
+  skip:
+    - test
 
 sdk:
   displayName: React Native


### PR DESCRIPTION
The React Native SDK doesn't have any unit tests. If you run `npm test`, you'll get a non-zero status code per [this line](https://github.com/launchdarkly/react-native-client-sdk/blob/master/package.json#L7). As a result we should skip the `npm test` phase of releasing.