### PR TITLE
prepare 2.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LaunchDarkly overview
 Supported versions
 -------------------------
 
-This SDK is compatible with React Native 0.59.9 and Xcode 10.2.1 and is tested in Android 27 and iOS 12.2. Earlier versions of this SDK are compatible with prior versions of React Native, Android, and iOS.
+This SDK is compatible with React Native 0.61.2 and Xcode 10.2.1 and is tested in Android 27 and iOS 12.2. Earlier versions of this SDK are compatible with prior versions of React Native, Android, and iOS.
 
 Getting started
 ---------------

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ allprojects {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:2.8.5'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:2.9.0'
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation "com.google.code.gson:gson:2.8.5"
 }

--- a/ios/LaunchdarklyReactNativeClient.podspec
+++ b/ios/LaunchdarklyReactNativeClient.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "LaunchdarklyReactNativeClient"
-  s.version      = "2.0.1"
+  s.version      = "2.1.0"
   s.summary      = "LaunchdarklyReactNativeClient"
   s.description  = <<-DESC
                   LaunchdarklyReactNativeClient
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency "React"
-  s.dependency "LaunchDarkly", "4.1.2"
+  s.dependency "LaunchDarkly", "4.3.2"
 
 end

--- a/ios/LaunchdarklyReactNativeClient.swift
+++ b/ios/LaunchdarklyReactNativeClient.swift
@@ -6,16 +6,18 @@ import LaunchDarkly
 class LaunchdarklyReactNativeClient: RCTEventEmitter {
     private var listenerKeys: [String:LDObserverOwner] = [:]
     
-    private let EVENT_PREFIX = "LaunchDarkly--"
+    private let FLAG_PREFIX = "LaunchDarkly-Flag-"
+    private let ALL_FLAGS_PREFIX = "LaunchDarkly-All-Flags-"
+    private let CONNECTION_MODE_PREFIX = "LaunchDarkly-Connection-Mode-"
     private let ERROR_INIT = "E_INITIALIZE"
     private let ERROR_IDENTIFY = "E_IDENTIFY"
     
     override func supportedEvents() -> [String]! {
-        return [EVENT_PREFIX]
+        return [FLAG_PREFIX, ALL_FLAGS_PREFIX, CONNECTION_MODE_PREFIX]
     }
     
     override func constantsToExport() -> [AnyHashable: Any] {
-        return ["EVENT_PREFIX": EVENT_PREFIX]
+        return ["FLAG_PREFIX": FLAG_PREFIX, "ALL_FLAGS_PREFIX": ALL_FLAGS_PREFIX, "CONNECTION_MODE_PREFIX": CONNECTION_MODE_PREFIX]
     }
     
     override static func requiresMainQueueSetup() -> Bool {
@@ -193,6 +195,67 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
     @objc func jsonVariationObject(_ flagKey: String, fallback: NSDictionary, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         resolve(LDClient.shared.variation(forKey: flagKey, fallback: fallback.swiftDictionary) as NSDictionary)
     }
+    
+    @objc func boolVariationDetailFallback(_ flagKey: String, fallback: ObjCBool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback.boolValue))
+    }
+    
+    @objc func intVariationDetailFallback(_ flagKey: String, fallback: Int, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback))
+    }
+    
+    @objc func floatVariationDetailFallback(_ flagKey: String, fallback: CGFloat, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: Double(fallback)))
+    }
+    
+    @objc func stringVariationDetailFallback(_ flagKey: String, fallback: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback))
+    }
+    
+    @objc func boolDetailVariation(_ flagKey: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        let boolFlagValue: EvaluationDetail<Bool?> = LDClient.shared.variationDetail(forKey: flagKey)
+        resolve(boolFlagValue)
+    }
+    
+    @objc func intDetailVariation(_ flagKey: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        let intFlagValue: EvaluationDetail<Int?> = LDClient.shared.variationDetail(forKey: flagKey)
+        resolve(intFlagValue)
+    }
+    
+    @objc func floatDetailVariation(_ flagKey: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        let floatFlagValue: EvaluationDetail<Double?> = LDClient.shared.variationDetail(forKey: flagKey)
+        resolve(floatFlagValue)
+    }
+    
+    @objc func stringDetailVariation(_ flagKey: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        let stringFlagValue: EvaluationDetail<String?> = LDClient.shared.variationDetail(forKey: flagKey)
+        resolve(stringFlagValue)
+    }
+    
+    @objc func jsonVariationDetailNone(_ flagKey: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        let jsonFlagValue: EvaluationDetail<Dictionary<String, Any>?> = LDClient.shared.variationDetail(forKey: flagKey)
+        resolve(jsonFlagValue)
+    }
+    
+    @objc func jsonVariationDetailNumber(_ flagKey: String, fallback: Double, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback))
+    }
+    
+    @objc func jsonVariationDetailBool(_ flagKey: String, fallback: Bool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback))
+    }
+    
+    @objc func jsonVariationDetailString(_ flagKey: String, fallback: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback))
+    }
+    
+    @objc func jsonVariationDetailArray(_ flagKey: String, fallback: Array<RCTConvert>, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback))
+    }
+    
+    @objc func jsonVariationDetailObject(_ flagKey: String, fallback: NSDictionary, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.variationDetail(forKey: flagKey, fallback: fallback.swiftDictionary))
+    }
 
     @objc func trackNumber(_ eventName: String, data: NSNumber) -> Void {
         try? LDClient.shared.trackEvent(key: eventName, data: data)
@@ -216,6 +279,30 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
 
     @objc func track(_ eventName: String) -> Void {
         try? LDClient.shared.trackEvent(key: eventName)
+    }
+    
+    @objc func trackNumberMetricValue(_ eventName: String, data: NSNumber, metricValue: Double) -> Void {
+        try? LDClient.shared.trackEvent(key: eventName, data: data, metricValue: metricValue)
+    }
+    
+    @objc func trackBoolMetricValue(_ eventName: String, data: ObjCBool, metricValue: Double) -> Void {
+        try? LDClient.shared.trackEvent(key: eventName, data: data.boolValue, metricValue: metricValue)
+    }
+    
+    @objc func trackStringMetricValue(_ eventName: String, data: String, metricValue: Double) -> Void {
+        try? LDClient.shared.trackEvent(key: eventName, data: data, metricValue: metricValue)
+    }
+    
+    @objc func trackArrayMetricValue(_ eventName: String, data: NSArray, metricValue: Double) -> Void {
+        try? LDClient.shared.trackEvent(key: eventName, data: data, metricValue: metricValue)
+    }
+    
+    @objc func trackObjectMetricValue(_ eventName: String, data: NSDictionary, metricValue: Double) -> Void {
+        try? LDClient.shared.trackEvent(key: eventName, data: data.swiftDictionary, metricValue: metricValue)
+    }
+    
+    @objc func trackMetricValue(_ eventName: String, metricValue: Double) -> Void {
+        try? LDClient.shared.trackEvent(key: eventName, metricValue: metricValue)
     }
 
     @objc func setOffline(_ resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
@@ -246,15 +333,9 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
     @objc func identify(_ options: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         let user = userBuild(userConfig: options)
         if let usr = user {
-            LDClient.shared.observeFlagsUnchanged(owner: self) {
-                LDClient.shared.stopObserving(owner: self as LDObserverOwner)
+            LDClient.shared.identify(user: usr) {
                 resolve(nil)
             }
-            LDClient.shared.observeAll(owner: self) {_ in
-                LDClient.shared.stopObserving(owner: self as LDObserverOwner)
-                resolve(nil)
-            }
-            LDClient.shared.user = usr
         } else {
             reject(ERROR_IDENTIFY, "User could not be built using supplied configuration", nil)
         }
@@ -279,23 +360,63 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
         }
         LDClient.shared.observe(keys: [flagKey], owner: flagChangeOwner, handler: { (changedFlags) in
             if changedFlags[flagKey] != nil {
-                self.sendEvent(withName: self.EVENT_PREFIX, body: ["flagKey": flagKey])
+                self.sendEvent(withName: self.FLAG_PREFIX, body: ["flagKey": flagKey])
             }
         })
     }
     
-    @objc func unregisterFeatureFlagListener(_ flagKey: String) -> Void {
-        let flagChangeOwner = flagKey as LDObserverOwner
-        if listenerKeys[flagKey] == nil {
-            listenerKeys.removeValue(forKey: flagKey)
+    private func unregisterListener(_ key: String) -> Void {
+        let owner = key as LDObserverOwner
+        if listenerKeys[key] != nil {
+            listenerKeys.removeValue(forKey: key)
         } else {
             return
         }
-        LDClient.shared.stopObserving(owner: flagChangeOwner)
+        LDClient.shared.stopObserving(owner: owner)
+    }
+    
+    @objc func unregisterFeatureFlagListener(_ flagKey: String) -> Void {
+        unregisterListener(flagKey)
     }
     
     @objc func isDisableBackgroundPolling(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         resolve(LDClient.shared.config.enableBackgroundUpdates)
+    }
+    
+    @objc func getConnectionInformation(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        resolve(LDClient.shared.getConnectionInformation())
+    }
+    
+    @objc func registerCurrentConnectionModeListener(_ listenerId: String) -> Void {
+        let currentConnectionModeOwner = listenerId as LDObserverOwner
+        if listenerKeys[listenerId] == nil {
+            listenerKeys.removeValue(forKey: listenerId)
+        } else {
+            return
+        }
+        LDClient.shared.observeCurrentConnectionMode(owner: currentConnectionModeOwner, handler: { (connectionMode) in
+            self.sendEvent(withName: self.CONNECTION_MODE_PREFIX, body: ["connectionMode": connectionMode])
+        })
+    }
+    
+    @objc func unregisterCurrentConnectionModeListener(_ listenerId: String) -> Void {
+        unregisterListener(listenerId)
+    }
+    
+    @objc func registerAllFlagsListener(_ listenerId: String) -> Void {
+        let flagChangeOwner = listenerId as LDObserverOwner
+        if listenerKeys[listenerId] == nil {
+            listenerKeys[listenerId] = flagChangeOwner
+        } else {
+            return
+        }
+        LDClient.shared.observeAll(owner: flagChangeOwner, handler: { (changedFlags) in
+            self.sendEvent(withName: self.ALL_FLAGS_PREFIX, body: ["flagKeys": changedFlags.description])
+        })
+    }
+    
+    @objc func unregisterAllFlagsListener(_ listenerId: String) -> Void {
+        unregisterListener(listenerId)
     }
 }
 

--- a/ios/LaunchdarklyReactNativeClientBridge.m
+++ b/ios/LaunchdarklyReactNativeClientBridge.m
@@ -33,6 +33,34 @@ RCT_EXTERN_METHOD(jsonVariationArray:(NSString *)flagKey fallback:(NSArray *)fal
 
 RCT_EXTERN_METHOD(jsonVariationObject:(NSString *)flagKey fallback:(NSDictionary *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(boolVariationDetailFallback:(NSString *)flagKey fallback:(BOOL *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(intVariationDetailFallback:(NSString *)flagKey fallback:(NSInteger *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(floatVariationDetailFallback:(NSString *)flagKey fallback:(CGFloat *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stringVariationDetailFallback:(NSString *)flagKey fallback:(NSString *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(boolVariationDetail:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(intVariationDetail:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(floatVariationDetail:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stringVariationDetail:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(jsonVariationDetailNone:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(jsonVariationDetailNumber:(NSString *)flagKey fallback:(NSNumber *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(jsonVariationDetailBool:(NSString *)flagKey fallback:(BOOL *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(jsonVariationDetailString:(NSString *)flagKey fallback:(NSString *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(jsonVariationDetailArray:(NSString *)flagKey fallback:(NSArray *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(jsonVariationDetailObject:(NSString *)flagKey fallback:(NSDictionary *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(trackBool:(NSString *)eventName data:(BOOL *)data)
 
 RCT_EXTERN_METHOD(trackArray:(NSString *)eventName data:(NSArray *)data)
@@ -44,6 +72,18 @@ RCT_EXTERN_METHOD(trackString:(NSString *)eventName data:(NSString *)data)
 RCT_EXTERN_METHOD(trackObject:(NSString *)eventName data:(NSDictionary *)data)
 
 RCT_EXTERN_METHOD(track:(NSString *)eventName)
+
+RCT_EXTERN_METHOD(trackBoolMetricValue:(NSString *)eventName data:(BOOL *)data metricValue:(NSNumber *)metricValue)
+
+RCT_EXTERN_METHOD(trackArrayMetricValue:(NSString *)eventName data:(NSArray *)data metricValue:(NSNumber *)metricValue)
+
+RCT_EXTERN_METHOD(trackNumberMetricValue:(NSString *)eventName data:(NSNumber *)data metricValue:(NSNumber *)metricValue)
+
+RCT_EXTERN_METHOD(trackStringMetricValue:(NSString *)eventName data:(NSString *)data metricValue:(NSNumber *)metricValue)
+
+RCT_EXTERN_METHOD(trackObjectMetricValue:(NSString *)eventName data:(NSDictionary *)data metricValue:(NSNumber *)metricValue)
+
+RCT_EXTERN_METHOD(trackMetricValue:(NSString *)eventName metricValue:(NSNumber *)metricValue)
 
 RCT_EXTERN_METHOD(setOffline:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
@@ -64,5 +104,15 @@ RCT_EXTERN_METHOD(registerFeatureFlagListener:(NSString *)flagKey)
 RCT_EXTERN_METHOD(unregisterFeatureFlagListener:(NSString *)flagKey)
 
 RCT_EXTERN_METHOD(isDisableBackgroundPolling:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getConnectionInformation:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(registerCurrentConnectionModeListener:(NSString *)listenerId)
+
+RCT_EXTERN_METHOD(unregisterCurrentConnectionModeListener:(NSString *)listenerId)
+
+RCT_EXTERN_METHOD(registerAllFlagsListener:(NSString *)listenerId)
+
+RCT_EXTERN_METHOD(unregisterAllFlagsListener:(NSString *)listenerId)
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-react-native-client-sdk",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## [2.1.0] - 2019-12-23
### Added:
- Implemented `variationDetail` which returns an Evaluation Reason giving developers greater insight into why a value was returned.
- Added `allFlagsListener` method, this returns flag keys whenever any flag key is updated.
- Added `metricValue` parameter to `track` method.
- The Connection Status API allows greater introspection into the current LaunchDarkly connection and the health of local flags.
	- This feature adds a new method called `getConnectionInformation` that returns an object that contains the current connection mode e.g. streaming or polling, when and how a connection failed, and the last time flags were updated.
	- Additionally, a new observer function called `registerCurrentConnectionModeListener` allows your application to listen to changes in the SDK's connection to LaunchDarkly.
- A `close()` method which flushes the event queue and closes all open connections to LaunchDarkly. This method should be invoked as part of your application's termination lifecycle event.

### Changed:
- Updated the iOS SDK to version 4.3.2. This enables the removal of `use_frameworks!` from the Podfile in a project using the LaunchDarkly React Native SDK.
- Updated the Android SDK to version 2.9.0.
- Switched iOS user switching from the deprecated `user` object to the `identify` method.
