### PR TITLE
prepare 2.2.2 release

### DIFF
--- a/.ldrelease/update-version.sh
+++ b/.ldrelease/update-version.sh
@@ -2,3 +2,6 @@
 
 sed  -i.bak "s/\( *\)s\.version\( *\)=\( *\)\".*\"/\1s\.version\2=\3\"${LD_RELEASE_VERSION}\"/" ios/LaunchdarklyReactNativeClient.podspec
 rm -f ios/LaunchdarklyReactNativeClient.podspec.bak
+
+sed  -i.bak "s/\( *\)\"version\"\( *\):\( *\)\".*\"/\1\"version\"\2:\3\"${LD_RELEASE_VERSION}\"/" package.json
+rm -f package.json.bak


### PR DESCRIPTION
## [2.2.2] - 2020-01-24
### Fixed:
- Fixes `package.json` versioning script.


