### PR TITLE
Check if bridge is available before sending an event

### DIFF
--- a/ios/LaunchdarklyReactNativeClient.swift
+++ b/ios/LaunchdarklyReactNativeClient.swift
@@ -446,7 +446,7 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
             return
         }
         LDClient.shared.observe(keys: [flagKey], owner: flagChangeOwner, handler: { (changedFlags) in
-            if changedFlags[flagKey] != nil {
+            if changedFlags[flagKey] != nil && self.bridge != nil {
                 self.sendEvent(withName: self.FLAG_PREFIX, body: ["flagKey": flagKey])
             }
         })
@@ -482,7 +482,9 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
             return
         }
         LDClient.shared.observeCurrentConnectionMode(owner: currentConnectionModeOwner, handler: { (connectionMode) in
-            self.sendEvent(withName: self.CONNECTION_MODE_PREFIX, body: ["connectionMode": connectionMode])
+            if self.bridge != nil {
+                self.sendEvent(withName: self.CONNECTION_MODE_PREFIX, body: ["connectionMode": connectionMode])
+            }
         })
     }
     
@@ -498,7 +500,9 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
             return
         }
         LDClient.shared.observeAll(owner: flagChangeOwner, handler: { (changedFlags) in
-            self.sendEvent(withName: self.ALL_FLAGS_PREFIX, body: ["flagKeys": changedFlags.description])
+            if self.bridge != nil {
+                self.sendEvent(withName: self.ALL_FLAGS_PREFIX, body: ["flagKeys": changedFlags.description])
+            }
         })
     }
     


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/react-native-client-sdk/issues/38

**Describe the solution you've provided**

For a solution, I have added a check if `self.bridge` is not nil before attempting to send an event. The nice thing is the callback that attempts to send the event gets called once the bridge is set and it successfully registers the listener.

**Describe alternatives you've considered**

N/A

**Additional context**

N/A
