### PR TITLE
fix: start background thread for identify rather than running it

### DIFF
--- a/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
+++ b/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
@@ -989,7 +989,7 @@ public class LaunchdarklyReactNativeClientModule extends ReactContextBaseJavaMod
                 }
             }
         });
-        background.run();
+        background.start();
     }
 
     @ReactMethod


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

_None_

**Describe the solution you've provided**

The identify call is running the identify code synchronously instead of
starting the background thread.

This results in it blocking the calling JavaScript thread, essentially
making it a synchronous call even though it's returning an asynchronous
promise.

This fixes the typo so we start the thread which SHOULD make this
non-blocking for the calling react native app.

**Describe alternatives you've considered**

None. This seems like a clear unintended typo as there's no reason to wrap the code in a thread if it was intended to be synchronous.

**Additional context**

Have not tested this as it seems like a pretty clear cut typo. Have verified that the current implementation blocks react native in the context of a react native app.
