### PR TITLE
prepare 4.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,3 @@ About LaunchDarkly
     * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides
     * [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/  "LaunchDarkly API Documentation") for our API documentation
     * [blog.launchdarkly.com](https://blog.launchdarkly.com/  "LaunchDarkly Blog Documentation") for the latest product updates
-    * [Feature Flagging Guide](https://github.com/launchdarkly/featureflags/  "Feature Flagging Guide") for best practices and strategies

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LaunchDarkly overview
 Supported versions
 -------------------------
 
-This SDK is compatible with React Native 0.62.x and Xcode 11.4 and is tested in Android 27 and iOS 12.4. Earlier versions of this SDK are compatible with prior versions of React Native, Android, and iOS.
+This SDK is compatible with React Native 0.62.x and Xcode 12 and is tested in Android 27 and iOS 13.5. Earlier versions of this SDK are compatible with prior versions of React Native, Android, and iOS.
 
 Getting started
 ---------------

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ allprojects {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:2.10.0'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:2.14.1'
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation "com.google.code.gson:gson:2.8.5"
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
+import { version } from './package.json';
 
 let LaunchdarklyReactNativeClient = NativeModules.LaunchdarklyReactNativeClient;
 
@@ -13,110 +14,124 @@ export default class LDClient {
     this.eventEmitter.addListener(LaunchdarklyReactNativeClient.CONNECTION_MODE_PREFIX, body => this._connectionModeUpdateListener(body));
   }
 
-  configure(config, userConfig) {
+  getVersion() {
+    return String(version);
+  }
+
+  configure(config, user, timeout) {
+    if (this.isInitialized() == true) {
+      Promise.reject('LaunchDarkly SDK already initialized');
+    }
     const configWithOverriddenDefaults = Object.assign({
       backgroundPollingIntervalMillis: 3600000, // the iOS SDK defaults this to 900000
-      disableBackgroundUpdating: false          // the iOS SDK defaults this to true
+      disableBackgroundUpdating: false,         // the iOS SDK defaults this to true
+      pollUri: 'https://clientsdk.launchdarkly.com',
+      wrapperName: 'react-native-client-sdk',
+      wrapperVersion: this.getVersion()
     }, config);
     
-    return LaunchdarklyReactNativeClient.configure(configWithOverriddenDefaults, this._addUserOverrides(userConfig));
+    if (timeout == undefined) {
+      return LaunchdarklyReactNativeClient.configure(configWithOverriddenDefaults, this._addUserOverrides(user));
+    } else {
+      return LaunchdarklyReactNativeClient.configureWithTimeout(configWithOverriddenDefaults, this._addUserOverrides(user), timeout);
+    }
   }
 
-  boolVariation(flagKey, fallback) {
-    if (fallback == undefined) {
+  boolVariation(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.boolVariation(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.boolVariationFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.boolVariationDefaultValue(flagKey, defaultValue);
     }
   }
 
-  intVariation(flagKey, fallback) {
-    if (fallback == undefined) {
+  intVariation(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.intVariation(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.intVariationFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.intVariationDefaultValue(flagKey, defaultValue);
     }
   }
 
-  floatVariation(flagKey, fallback) {
-    if (fallback == undefined) {
+  floatVariation(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.floatVariation(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.floatVariationFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.floatVariationDefaultValue(flagKey, defaultValue);
     }
   }
 
-  stringVariation(flagKey, fallback) {
-    if (fallback == undefined) {
+  stringVariation(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.stringVariation(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.stringVariationFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.stringVariationDefaultValue(flagKey, defaultValue);
     }
   }
 
-  jsonVariation(flagKey, fallback) {
-    if (fallback == undefined) {
+  jsonVariation(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.jsonVariationNone(flagKey);
-    } else if (typeof fallback === 'number') {
-      return LaunchdarklyReactNativeClient.jsonVariationNumber(flagKey, fallback);
-    } else if (typeof fallback === 'boolean') {
-      return LaunchdarklyReactNativeClient.jsonVariationBool(flagKey, fallback);
-    } else if (typeof fallback === 'string') {
-      return LaunchdarklyReactNativeClient.jsonVariationString(flagKey, fallback);
-    } else if (Array.isArray(fallback)) {
-      return LaunchdarklyReactNativeClient.jsonVariationArray(flagKey, fallback);
+    } else if (typeof defaultValue === 'number') {
+      return LaunchdarklyReactNativeClient.jsonVariationNumber(flagKey, defaultValue);
+    } else if (typeof defaultValue === 'boolean') {
+      return LaunchdarklyReactNativeClient.jsonVariationBool(flagKey, defaultValue);
+    } else if (typeof defaultValue === 'string') {
+      return LaunchdarklyReactNativeClient.jsonVariationString(flagKey, defaultValue);
+    } else if (Array.isArray(defaultValue)) {
+      return LaunchdarklyReactNativeClient.jsonVariationArray(flagKey, defaultValue);
     } else {
       // Should be an object
-      return LaunchdarklyReactNativeClient.jsonVariationObject(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.jsonVariationObject(flagKey, defaultValue);
     }
   }
 
-  boolVariationDetail(flagKey, fallback) {
-    if (fallback == undefined) {
+  boolVariationDetail(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.boolVariationDetail(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.boolVariationDetailFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.boolVariationDetailDefaultValue(flagKey, defaultValue);
     }
   }
 
-  intVariationDetail(flagKey, fallback) {
-    if (fallback == undefined) {
+  intVariationDetail(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.intVariationDetail(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.intVariationDetailFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.intVariationDetailDefaultValue(flagKey, defaultValue);
     }
   }
 
-  floatVariationDetail(flagKey, fallback) {
-    if (fallback == undefined) {
+  floatVariationDetail(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.floatVariationDetail(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.floatVariationDetailFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.floatVariationDetailDefaultValue(flagKey, defaultValue);
     }
   }
 
-  stringVariationDetail(flagKey, fallback) {
-    if (fallback == undefined) {
+  stringVariationDetail(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.stringVariationDetail(flagKey);
     } else {
-      return LaunchdarklyReactNativeClient.stringVariationDetailFallback(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.stringVariationDetailDefaultValue(flagKey, defaultValue);
     }
   }
 
-  jsonVariationDetail(flagKey, fallback) {
-    if (fallback == undefined) {
+  jsonVariationDetail(flagKey, defaultValue) {
+    if (defaultValue == undefined) {
       return LaunchdarklyReactNativeClient.jsonVariatioDetailNone(flagKey);
-    } else if (typeof fallback === 'number') {
-      return LaunchdarklyReactNativeClient.jsonVariationDetailNumber(flagKey, fallback);
-    } else if (typeof fallback === 'boolean') {
-      return LaunchdarklyReactNativeClient.jsonVariationDetailBool(flagKey, fallback);
-    } else if (typeof fallback === 'string') {
-      return LaunchdarklyReactNativeClient.jsonVariationDetailString(flagKey, fallback);
-    } else if (Array.isArray(fallback)) {
-      return LaunchdarklyReactNativeClient.jsonVariationDetailArray(flagKey, fallback);
+    } else if (typeof defaultValue === 'number') {
+      return LaunchdarklyReactNativeClient.jsonVariationDetailNumber(flagKey, defaultValue);
+    } else if (typeof defaultValue === 'boolean') {
+      return LaunchdarklyReactNativeClient.jsonVariationDetailBool(flagKey, defaultValue);
+    } else if (typeof defaultValue === 'string') {
+      return LaunchdarklyReactNativeClient.jsonVariationDetailString(flagKey, defaultValue);
+    } else if (Array.isArray(defaultValue)) {
+      return LaunchdarklyReactNativeClient.jsonVariationDetailArray(flagKey, defaultValue);
     } else {
       // Should be an object
-      return LaunchdarklyReactNativeClient.jsonVariationDetailObject(flagKey, fallback);
+      return LaunchdarklyReactNativeClient.jsonVariationDetailObject(flagKey, defaultValue);
     }
   }
 
@@ -171,11 +186,7 @@ export default class LDClient {
   }
 
   isInitialized() {
-    if(Platform.OS === 'android') {
-      return LaunchdarklyReactNativeClient.isInitialized();
-    } else {
-      return Promise.reject("Function is not available on this platform");
-    }
+    return LaunchdarklyReactNativeClient.isInitialized();
   }
 
   flush() {
@@ -186,18 +197,14 @@ export default class LDClient {
     LaunchdarklyReactNativeClient.close();
   }
 
-  identify(userConfig) {
-    return LaunchdarklyReactNativeClient.identify(this._addUserOverrides(userConfig));
+  identify(user) {
+    return LaunchdarklyReactNativeClient.identify(this._addUserOverrides(user));
   }
 
-  _addUserOverrides(userConfig) {
+  _addUserOverrides(user) {
     return Object.assign({
       anonymous: false   // the iOS SDK defaults this to true
-    }, userConfig);
-  }
-
-  isDisableBackgroundPolling() {
-    return LaunchdarklyReactNativeClient.isDisableBackgroundPolling();
+    }, user);
   }
 
   _flagUpdateListener(changedFlag) {
@@ -253,10 +260,6 @@ export default class LDClient {
     }
   }
 
-  getConnectionInformation() {
-    return LaunchdarklyReactNativeClient.getConnectionInformation();
-  }
-
   registerCurrentConnectionModeListener(listenerId, callback) {
     if (typeof callback !== "function") {
       return;
@@ -289,5 +292,21 @@ export default class LDClient {
 
     LaunchdarklyReactNativeClient.unregisterAllFlagsListener(listenerId);
     delete this.allFlagsListeners[listenerId];
+  }
+
+  getConnectionMode() {
+    return LaunchdarklyReactNativeClient.getConnectionMode();
+  }
+
+  getLastSuccessfulConnection() {
+    return LaunchdarklyReactNativeClient.getLastSuccessfulConnection();
+  }
+
+  getLastFailedConnection() {
+    return LaunchdarklyReactNativeClient.getLastFailedConnection();
+  }
+
+  getLastFailure() {
+    return LaunchdarklyReactNativeClient.getLastFailure();
   }
 }

--- a/ios/LaunchdarklyReactNativeClient.podspec
+++ b/ios/LaunchdarklyReactNativeClient.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency "React"
-  s.dependency "LaunchDarkly", "4.5.0"
+  s.dependency "LaunchDarkly", "5.4.0"
 
 end

--- a/ios/LaunchdarklyReactNativeClientBridge.m
+++ b/ios/LaunchdarklyReactNativeClientBridge.m
@@ -3,15 +3,17 @@
 
 @interface RCT_EXTERN_MODULE(LaunchdarklyReactNativeClient, RCTEventEmitter)
 
-RCT_EXTERN_METHOD(configure:(NSDictionary *)config userConfig:(NSDictionary *)userConfig resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(configure:(NSDictionary *)config user:(NSDictionary *)user resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(boolVariationFallback:(NSString *)flagKey fallback:(BOOL *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(configureWithTimeout:(NSDictionary *)config userConfig:(NSDictionary *)userConfig timeout:(NSInteger *)timeout resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(intVariationFallback:(NSString *)flagKey fallback:(NSInteger *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(boolVariationDefaultValue:(NSString *)flagKey defaultValue:(BOOL *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(floatVariationFallback:(NSString *)flagKey fallback:(CGFloat *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(intVariationDefaultValue:(NSString *)flagKey defaultValue:(NSInteger *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(stringVariationFallback:(NSString *)flagKey fallback:(NSString *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(floatVariationDefaultValue:(NSString *)flagKey defaultValue:(CGFloat *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stringVariationDefaultValue:(NSString *)flagKey defaultValue:(NSString *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(boolVariation:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
@@ -23,23 +25,23 @@ RCT_EXTERN_METHOD(stringVariation:(NSString *)flagKey resolve:(RCTPromiseResolve
 
 RCT_EXTERN_METHOD(jsonVariationNone:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationNumber:(NSString *)flagKey fallback:(NSNumber *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationNumber:(NSString *)flagKey defaultValue:(NSNumber *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationBool:(NSString *)flagKey fallback:(BOOL *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationBool:(NSString *)flagKey defaultValue:(BOOL *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationString:(NSString *)flagKey fallback:(NSString *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationString:(NSString *)flagKey defaultValue:(NSString *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationArray:(NSString *)flagKey fallback:(NSArray *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationArray:(NSString *)flagKey defaultValue:(NSArray *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationObject:(NSString *)flagKey fallback:(NSDictionary *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationObject:(NSString *)flagKey defaultValue:(NSDictionary *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(boolVariationDetailFallback:(NSString *)flagKey fallback:(BOOL *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(boolVariationDetailDefaultValue:(NSString *)flagKey defaultValue:(BOOL *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(intVariationDetailFallback:(NSString *)flagKey fallback:(NSInteger *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(intVariationDetailDefaultValue:(NSString *)flagKey defaultValue:(NSInteger *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(floatVariationDetailFallback:(NSString *)flagKey fallback:(CGFloat *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(floatVariationDetailDefaultValue:(NSString *)flagKey defaultValue:(CGFloat *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(stringVariationDetailFallback:(NSString *)flagKey fallback:(NSString *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(stringVariationDetailDefaultValue:(NSString *)flagKey defaultValue:(NSString *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(boolVariationDetail:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
@@ -51,21 +53,21 @@ RCT_EXTERN_METHOD(stringVariationDetail:(NSString *)flagKey resolve:(RCTPromiseR
 
 RCT_EXTERN_METHOD(jsonVariationDetailNone:(NSString *)flagKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationDetailNumber:(NSString *)flagKey fallback:(NSNumber *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationDetailNumber:(NSString *)flagKey defaultValue:(NSNumber *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationDetailBool:(NSString *)flagKey fallback:(BOOL *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationDetailBool:(NSString *)flagKey defaultValue:(BOOL *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationDetailString:(NSString *)flagKey fallback:(NSString *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationDetailString:(NSString *)flagKey defaultValue:(NSString *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationDetailArray:(NSString *)flagKey fallback:(NSArray *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationDetailArray:(NSString *)flagKey defaultValue:(NSArray *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(jsonVariationDetailObject:(NSString *)flagKey fallback:(NSDictionary *)fallback resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(jsonVariationDetailObject:(NSString *)flagKey defaultValue:(NSDictionary *)defaultValue resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(trackBool:(NSString *)eventName data:(BOOL *)data)
 
 RCT_EXTERN_METHOD(trackArray:(NSString *)eventName data:(NSArray *)data)
 
-RCT_EXTERN_METHOD(trackNumber:(NSString *)eventName data:(NSNumber *)data)
+RCT_EXTERN_METHOD(trackNumber:(NSString *)eventName data:(NSNumber * _Nonnull)data)
 
 RCT_EXTERN_METHOD(trackString:(NSString *)eventName data:(NSString *)data)
 
@@ -73,17 +75,17 @@ RCT_EXTERN_METHOD(trackObject:(NSString *)eventName data:(NSDictionary *)data)
 
 RCT_EXTERN_METHOD(track:(NSString *)eventName)
 
-RCT_EXTERN_METHOD(trackBoolMetricValue:(NSString *)eventName data:(BOOL *)data metricValue:(NSNumber *)metricValue)
+RCT_EXTERN_METHOD(trackBoolMetricValue:(NSString *)eventName data:(BOOL *)data metricValue:(NSNumber * _Nonnull)metricValue)
 
-RCT_EXTERN_METHOD(trackArrayMetricValue:(NSString *)eventName data:(NSArray *)data metricValue:(NSNumber *)metricValue)
+RCT_EXTERN_METHOD(trackArrayMetricValue:(NSString *)eventName data:(NSArray *)data metricValue:(NSNumber * _Nonnull)metricValue)
 
-RCT_EXTERN_METHOD(trackNumberMetricValue:(NSString *)eventName data:(NSNumber *)data metricValue:(NSNumber *)metricValue)
+RCT_EXTERN_METHOD(trackNumberMetricValue:(NSString *)eventName data:(NSNumber * _Nonnull)data metricValue:(NSNumber * _Nonnull)metricValue)
 
-RCT_EXTERN_METHOD(trackStringMetricValue:(NSString *)eventName data:(NSString *)data metricValue:(NSNumber *)metricValue)
+RCT_EXTERN_METHOD(trackStringMetricValue:(NSString *)eventName data:(NSString *)data metricValue:(NSNumber * _Nonnull)metricValue)
 
-RCT_EXTERN_METHOD(trackObjectMetricValue:(NSString *)eventName data:(NSDictionary *)data metricValue:(NSNumber *)metricValue)
+RCT_EXTERN_METHOD(trackObjectMetricValue:(NSString *)eventName data:(NSDictionary *)data metricValue:(NSNumber * _Nonnull)metricValue)
 
-RCT_EXTERN_METHOD(trackMetricValue:(NSString *)eventName metricValue:(NSNumber *)metricValue)
+RCT_EXTERN_METHOD(trackMetricValue:(NSString *)eventName metricValue:(NSNumber * _Nonnull)metricValue)
 
 RCT_EXTERN_METHOD(setOffline:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
@@ -103,10 +105,6 @@ RCT_EXTERN_METHOD(registerFeatureFlagListener:(NSString *)flagKey)
 
 RCT_EXTERN_METHOD(unregisterFeatureFlagListener:(NSString *)flagKey)
 
-RCT_EXTERN_METHOD(isDisableBackgroundPolling:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(getConnectionInformation:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(registerCurrentConnectionModeListener:(NSString *)listenerId)
 
 RCT_EXTERN_METHOD(unregisterCurrentConnectionModeListener:(NSString *)listenerId)
@@ -114,5 +112,15 @@ RCT_EXTERN_METHOD(unregisterCurrentConnectionModeListener:(NSString *)listenerId
 RCT_EXTERN_METHOD(registerAllFlagsListener:(NSString *)listenerId)
 
 RCT_EXTERN_METHOD(unregisterAllFlagsListener:(NSString *)listenerId)
+
+RCT_EXTERN_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getConnectionMode:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getLastSuccessfulConnection:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getLastFailedConnection:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getLastFailure:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end


### PR DESCRIPTION
## [4.0.0] - 2021-03-31
### Added:
- Added `getConnectionMode`, `getLastSuccessfulConnection`, `getLastFailedConnection`, and `getLastFailure` methods to `LDClient`. These methods can be used to report on the SDK&#39;s connection to LaunchDarkly. The new `LDConnectionMode` and `LDFailureReason` enum types have been added to support these methods. These methods replace the `getConnectionInformation` method which behaved differently across platforms.
- Added a `getVersion` method to `LDClient` to get the version of the React Native SDK.
- Added an optional `timeout` value to the `configure` method to specify that the SDK should block up to a specified duration while initializing.
- Added a new client configuration option, `maxCachedUsers`, to `LDClientConfig`. You can now specify the number of users to be cached locally on the device or use `-1` for unlimited cached users.
- Added new user configuration options, `ip` and `avatar`, to `LDUserConfig`.
- The SDK now periodically sends diagnostic data to LaunchDarkly, describing the version and configuration of the SDK, the operating system the SDK is running on, the device type (such as &#34;iPad&#34;), and performance statistics. No credentials, device IDs, or other identifiable values are included. This behavior can be disabled or configured with the new `LDClientConfig` properties `diagnosticOptOut` and `diagnosticRecordingInterval`.
- Added reporting of the SDK&#39;s &#34;wrapper name&#34; and &#34;wrapper version&#34; for internal reporting purposes.
- iOS: Added XCode 12 support ([#64](https://github.com/launchdarkly/react-native-client-sdk/issues/64))
- iOS: Added support for the `isInitialized` method. Previously this method only worked when running on Android.

### Changed:
- Renamed the `LDClientConfig` type to `LDConfig` for consistency with other LaunchDarkly SDKs. Corresponding parameter names and documentation have also been updated to reflect this change.
- Renamed the `LDUserConfig` type to `LDUser` for consistency with other LaunchDarkly SDKs. Corresponding parameter names and documentation have also been updated to reflect this change.
- Renamed `baseUri` in `LDConfig` (formerly `LDClientConfig`) to `pollUri` to clarify that this URI is only used when polling.
- The `fallback` parameter of all `LDClient` variation methods has been renamed to `defaultValue` to help distinguish it from `fallback` values in rules specified in the LaunchDarkly dashboard.
- Changed the default polling domain from `app.launchdarkly.com` to `clientsdk.launchdarkly.com`.
- Android: Updated the Android SDK native module from 2.10.0 to [2.14.1](https://github.com/launchdarkly/android-client-sdk/releases/tag/2.14.1)
- Android: Error stacktrace logging in the bridge layer now uses Timber instead of `System.err`
- iOS: Updated the iOS SDK native module from 4.5.0 to [5.4.0](https://github.com/launchdarkly/ios-client-sdk/releases/tag/5.4.0) ([#65](https://github.com/launchdarkly/react-native-client-sdk/issues/65))
- iOS: The minimum iOS deployment target has been updated from 8.0 to 10.0.
- iOS: The maximum backoff delay between failed streaming connections has been reduced from an hour to 30 seconds. This is to prevent being unable to receive new flag values for up to an hour if the SDK has reached its maximum backoff due to a period of network connectivity loss.
- iOS: The backoff on streaming connections will not be reset after just a successful connection, rather waiting for a healthy connection for one minute after receiving flags. This is to reduce congestion in poor network conditions or if extreme load prevents the LaunchDarkly service from maintaining an active streaming connection.
- iOS: When sending events to LaunchDarkly, the SDK will now retry the request after a one second delay if it fails.
- iOS: When events fail to be sent to LaunchDarkly, the SDK will no longer retain the events. This prevents double recording events when the LaunchDarkly service received the event but the SDK failed to receive the acknowledgement.

### Fixed:
- The `getConnectionInformation` method in `LDClient` had inconsistent return types across the iOS and Android platforms. This API has been split into separate methods which are consistently typed across platforms - see the notes above. ([#59](https://github.com/launchdarkly/react-native-client-sdk/issues/59))
- Android: Fixed an issue where `identify` ran on the current thread instead of on a background thread (thanks, [orthanc](https://github.com/launchdarkly/react-native-client-sdk/pull/66) and [hackdie](https://github.com/launchdarkly/react-native-client-sdk/pull/58)!)
- Android: Fixed an issue where an exception was thrown if `configure` was invoked multiple times. Now, subsequent invocations result in a rejected promise. ([#40](https://github.com/launchdarkly/react-native-client-sdk/issues/40))
- Android: Fixed an issue where the `evaluationReasons` option in `LDClientConfig` was not used when configuring the Android SDK native module.
- Android: Fixed an issue where `NullPointerException`s were possible if certain methods were invoked while the client was initializing (discussed in [#55](https://github.com/launchdarkly/react-native-client-sdk/issues/55#issuecomment-681173212))
- Android: Fixed an issue where initialization may never complete if the network status of foreground state changed before the future had completed.
- Android: Fixed an issue where a `NullPointerException` could occur when calling a variation method with a flag key that does not exist locally or is of the wrong type. This issue could only occur if a null fallback value was provided.
- Android: Improved event summarization logic to avoid potential runtime exceptions.
- Android: Internal throttling logic would sometimes delay new poll or stream connections even when there were no recent connections. This caused switching active user contexts using `identify` to sometimes delay retrieving the most recent flags, and therefore delay the completion of the returned Promise.
- Android: Previously, the SDK manifest required the SET_ALARM permission. This permission was never used, so it has been removed.
- Android: Improved handling of exceptions thrown by the alarm manager on Samsung devices.
- iOS: Fixed an issue preventing private custom attribute names being recorded in events when all custom attributes are set to be private by including &#34;custom&#34; in the `LDUserConfig.privateAttributeNames` or `LDClientConfig.allUserAttributesPrivate` properties.
- iOS: Fixed an issue to prevent a crash that would rarely occur as the SDK transitioned to an online state for a given configuration or user. This issue may have been exacerbated for a short period due to a temporary change in the behavior of the LaunchDarkly service streaming endpoint.
- OS: Fix `metricValue` argument to `track` to work with all numbers.

### Removed:
- Removed the `LDClientConfig` type.
- Removed the `LDUserConfig` type.
- Removed the `getConnectionInformation` method in `LDClient`.
- Removed the `isDisableBackgroundPolling` method in `LDClient`.
- Removed the `baseUri` attribute in `LDConfig` (formerly `LDClientConfig`).
