### PR TITLE
Remove any forcing for LDClient.get() to a null check first. This wil…

### DIFF
--- a/ios/LaunchdarklyReactNativeClient.swift
+++ b/ios/LaunchdarklyReactNativeClient.swift
@@ -449,34 +449,34 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
     }
 
     @objc func setOffline(_ resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        LDClient.get()!.setOnline(false) {
+        LDClient.get()?.setOnline(false) {
             return resolve(true)
         }
     }
     
     @objc func isOffline(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        resolve(LDClient.get()!.isOnline)
+        resolve(LDClient.get()?.isOnline)
     }
     
     @objc func setOnline(_ resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        LDClient.get()!.setOnline(true) {
+        LDClient.get()?.setOnline(true) {
             return resolve(true)
         }
     }
     
     @objc func flush() -> Void {
-        LDClient.get()!.flush()
+        LDClient.get()?.flush()
     }
     
     @objc func close(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        LDClient.get()!.close()
+        LDClient.get()?.close()
         resolve(true)
     }
     
     @objc func identify(_ options: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         let user = userBuild(userDict: options)
         if let usr = user {
-            LDClient.get()!.identify(user: usr) {
+            LDClient.get()?.identify(user: usr) {
                 resolve(nil)
             }
         } else {


### PR DESCRIPTION
…l prevent issue #75 (causing a crash when closing the LDClient).

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

[#75](https://github.com/launchdarkly/react-native-client-sdk/issues/75) 

**Describe the solution you've provided**

Solution is a basic one, not forcing the LDClient to have a value while calling the .get(), by adding a null coalescing operator.

**Describe alternatives you've considered**

Considered throwing an error indicating the actual issue, so that it can be handled elsewhere, but will wait for your feedback on this approach.
