### PR TITLE
Change android client module to pass keys as string[] instead of json

### DIFF
--- a/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
+++ b/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
@@ -774,8 +774,13 @@ public class LaunchdarklyReactNativeClientModule extends ReactContextBaseJavaMod
         LDAllFlagsListener listener = new LDAllFlagsListener() {
             @Override
             public void onChange(List<String> flagKeys) {
+                WritableArray flagKeysArray = Arguments.createArray();
+                for (String flagKey: flagKeys) {
+                    flagKeysArray.pushString((flagKey));
+                }
+
                 WritableMap result = Arguments.createMap();
-                result.putString("flagKeys", gson.toJson(flagKeys));
+                result.putArray("flagKeys", flagKeysArray);
                 result.putString("listenerId", multiListenerId);
 
                 getReactApplicationContext()


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

#89 

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

The android client module now provides the flags as an array to the listener instead of a json string

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

I considered doing a type check on the javascript side of the listener and parsing the string. This felt more correct

**Additional context**

Add any other context about the pull request here.

I had difficulties testing that this works myself, I am not a native mobile dev and have only just begun with react native. I also didnt have a key in which to setup the hello-react-native project, but that doesn't seem to be using this function anyway. I hop e the changes are clear enough that the reviews can verify without that being required.
