### PR TITLE
Android: Make AllFlagsListener emit an array of strings

### DIFF
--- a/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
+++ b/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
@@ -775,7 +775,7 @@ public class LaunchdarklyReactNativeClientModule extends ReactContextBaseJavaMod
             @Override
             public void onChange(List<String> flagKeys) {
                 WritableMap result = Arguments.createMap();
-                result.putString("flagKeys", gson.toJson(flagKeys));
+                result.putArray("flagKeys", Arguments.fromList(flagKeys));
                 result.putString("listenerId", multiListenerId);
 
                 getReactApplicationContext()


### PR DESCRIPTION
This fixes the issue reported in https://github.com/launchdarkly/react-native-client-sdk/issues/89.
The AllFlagsListener was previously emitting a stringified array, which is not consistent with iOS nor the provided type definitions.

**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/react-native-client-sdk/issues/89

**Describe the solution you've provided**

Simply emit an actual array instead of a stringified array.

