### PR TITLE
Update peerDependencies to officially mark RN 0.68 as supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://docs.launchdarkly.com/sdk/client-side/react-native",
   "peerDependencies": {
-    "react-native": ">=0.64.0 <0.68.0"
+    "react-native": ">=0.64.0 <0.69.0"
   },
   "devDependencies": {
     "jest": "^26.6.3",


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Fixes #130

**Describe the solution you've provided**

With the release of React Native 0.68, this library should add support for that newer version.
