### PR TITLE
Add isInitializedSafe which doesn't throw an exception when client is already initialised

### DIFF
--- a/__mocks__/native.js
+++ b/__mocks__/native.js
@@ -52,6 +52,7 @@ const mockNativeModule = {
   isOffline: jest.fn(),
   setOnline: jest.fn(),
   isInitialized: jest.fn(),
+  isInitializedSafe: jest.fn(),
   flush: jest.fn(),
   close: jest.fn(),
   identify: jest.fn(),

--- a/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
+++ b/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
@@ -589,6 +589,16 @@ public class LaunchdarklyReactNativeClientModule extends ReactContextBaseJavaMod
             promise.reject(ERROR_UNKNOWN, e);
         }
     }
+    
+    @ReactMethod
+    public void isInitializedSafe(String environment, Promise promise) {
+        try {
+            boolean result = LDClient.getForMobileKey(environment).isInitialized();
+            promise.resolve(result);
+        } catch (Exception e) {
+            promise.resolve(true);
+        }
+    }
 
     @ReactMethod
     public void flush() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -702,6 +702,18 @@ declare module 'launchdarkly-react-native-client-sdk' {
         isInitialized(environment?: string): Promise<boolean>;
         
         /**
+         * Same functionality as isInitialized but does not return a rejected promise in case the client has 
+         * been already initialized. Instead the function will return either true or false depending on the 
+         * client state.
+         *
+         * @param environment
+         *   Optional environment name to obtain the result from the corresponding secondary environment
+         * @returns 
+         *   A promise containing true if the client is initialized or offline, otherwise false
+         */
+        isInitializedSafe(environment?: string): Promise<boolean>;
+        
+        /**
          * Flushes all pending analytics events.
          *
          * Normally, batches of events are delivered in the background at intervals determined by the

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ export default class LDClient {
     return LaunchdarklyReactNativeClient.isInitialized(env);
   }
   
-  isInitialized(environment) {
+  isInitializedSafe(environment) {
     const env = environment !== undefined ? environment : "default";
     return LaunchdarklyReactNativeClient.isInitializedSafe(env);
   }

--- a/index.js
+++ b/index.js
@@ -187,6 +187,11 @@ export default class LDClient {
     const env = environment !== undefined ? environment : "default";
     return LaunchdarklyReactNativeClient.isInitialized(env);
   }
+  
+  isInitialized(environment) {
+    const env = environment !== undefined ? environment : "default";
+    return LaunchdarklyReactNativeClient.isInitializedSafe(env);
+  }
 
   flush() {
     LaunchdarklyReactNativeClient.flush();

--- a/index.test.js
+++ b/index.test.js
@@ -210,6 +210,17 @@ test('isInitialized', () => {
   expect(nativeMock.isInitialized).toHaveBeenNthCalledWith(2, 'alt');
 });
 
+test('isInitializedSafe', () => {
+  nativeMock.isInitializedSafe.mockReturnValueOnce(false);
+  expect(client.isInitializedSafe()).toBe(false);
+  nativeMock.isInitializedSafe.mockReturnValueOnce(true);
+  expect(client.isInitializedSafe('alt')).toBe(true);
+
+  expect(nativeMock.isInitializedSafe).toHaveBeenCalledTimes(2);
+  expect(nativeMock.isInitializedSafe).toHaveBeenNthCalledWith(1, 'default');
+  expect(nativeMock.isInitializedSafe).toHaveBeenNthCalledWith(2, 'alt');
+});
+
 test('flush', () => {
   client.flush();
   expect(nativeMock.flush).toHaveBeenCalledTimes(1);

--- a/ios/LaunchdarklyReactNativeClient.swift
+++ b/ios/LaunchdarklyReactNativeClient.swift
@@ -446,6 +446,16 @@ class LaunchdarklyReactNativeClient: RCTEventEmitter {
             reject(ERROR_UNKNOWN, "SDK not configured with requested environment", nil)
         }
     }
+    
+    @objc func isInitializedSafe(_ environment: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        if LDClient.get() == nil {
+            reject(ERROR_UNKNOWN, "SDK has not been configured", nil)
+        } else if let client = LDClient.get(environment: environment) {
+            resolve(client.isInitialized)
+        } else {
+            resolve(true)
+        }
+    }
 }
 
 class ObserverOwner{}

--- a/ios/LaunchdarklyReactNativeClientBridge.m
+++ b/ios/LaunchdarklyReactNativeClientBridge.m
@@ -97,6 +97,8 @@ RCT_EXTERN_METHOD(unregisterAllFlagsListener:(NSString *)listenerId environment:
 
 RCT_EXTERN_METHOD(isInitialized:(NSString *)environment resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(isInitializedSafe:(NSString *)environment resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(getConnectionMode:(NSString *)environment resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getLastSuccessfulConnection:(NSString *)environment resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)

--- a/test-types.ts
+++ b/test-types.ts
@@ -112,6 +112,7 @@ async function tests() {
     const setOnline: boolean = await client.setOnline();
     const isOffline: boolean = await client.isOffline();
     const isInitialized: boolean = await client.isInitialized();
+    const isInitializedSafe: boolean = await client.isInitializedSafe();
 
     const callback = function(_: string): void { };
     const registerFeatureFlagListener: void = client.registerFeatureFlagListener('key', callback);


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Related to https://github.com/launchdarkly/react-native-client-sdk/issues/121.

**Describe the solution you've provided**

isInitialized always throws an exception when already initialised. It seems like an anti-pattern to provide a boolean for that method which actually never can be true (as someone would expect) - unless I am missing something? To prevent any breaking changes to others, but also provide a more expected way of dealing with isInitialized, I would suggest to add a "safe" alternative to isInitialized which doesn't error if already initialised.