### PR TITLE
add tvOS target

### DIFF
--- a/launchdarkly-react-native-client-sdk.podspec
+++ b/launchdarkly-react-native-client-sdk.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage     = package["homepage"]
   s.license      = { :type => "Apache-2.0", :file => "LICENSE" }
   s.author       = { "author" => "support@launchdarkly.com" }
-  s.platform     = :ios, "10.0"
+  s.platform     = { :ios => "10.0", :tvos => "11.0" }
   s.source       = { :git => "https://github.com/launchdarkly/react-native-client-sdk.git", :tag => s.version }
   s.source_files  = "ios/**/*.{h,m,swift}"
   s.swift_version = "5.0"


### PR DESCRIPTION
We successfully use LaunchDarkly SDK for tvOS platform, it's fully compatible. This change is the only thing that is required for successful compilation.