### PR TITLE
Fix Android build in monorepo setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,33 +33,42 @@ android {
     }
 }
 
-// allprojects {
-//     repositories {
-//         // Ripped from https://stackoverflow.com/questions/74333787/react-native-2-files-found-with-path-lib-arm64-v8a-libfbjni-so-from-inputs
-//         exclusiveContent {
-//             // We get React Native's Android binaries exclusively through npm,
-//             // from a local Maven repo inside node_modules/react-native/.
-//             // (The use of exclusiveContent prevents looking elsewhere like Maven Central
-//             // and potentially getting a wrong version.)
-//             filter {
-//                 includeGroup "com.facebook.react"
-//             }
-//             forRepository {
-//                 maven {
-//                     url "$rootDir/../node_modules/react-native/android"
-//                 }
-//             }
-//         }
+def resolvedNodeModulesDir = null
+try {
+    resolvedNodeModulesDir = new File(["node", "--print", "require.resolve('react-native')"].execute(null, rootDir).text.trim()).getParentFile().getParentFile();
+} catch (Throwable ignored) {}
 
-//         mavenLocal()
-//         google()
-//         mavenCentral()
-//         maven {
-//             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-//             url "$rootDir/../node_modules/react-native/android"
-//         }
-//     }
-// }
+def modulesPath = resolvedNodeModulesDir
+    ? resolvedNodeModulesDir
+    : "$rootDir/../node_modules"
+
+allprojects {
+    repositories {
+        // Ripped from https://stackoverflow.com/questions/74333787/react-native-2-files-found-with-path-lib-arm64-v8a-libfbjni-so-from-inputs
+        exclusiveContent {
+            // We get React Native's Android binaries exclusively through npm,
+            // from a local Maven repo inside node_modules/react-native/.
+            // (The use of exclusiveContent prevents looking elsewhere like Maven Central
+            // and potentially getting a wrong version.)
+            filter {
+                includeGroup "com.facebook.react"
+            }
+            forRepository {
+                maven {
+                    url "$modulesPath/react-native/android"
+                }
+            }
+        }
+
+        mavenLocal()
+        google()
+        mavenCentral()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "$modulesPath/react-native/android"
+        }
+    }
+}
 
 dependencies {
     implementation("com.facebook.react:react-native:+")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,33 +33,33 @@ android {
     }
 }
 
-allprojects {
-    repositories {
-        // Ripped from https://stackoverflow.com/questions/74333787/react-native-2-files-found-with-path-lib-arm64-v8a-libfbjni-so-from-inputs
-        exclusiveContent {
-            // We get React Native's Android binaries exclusively through npm,
-            // from a local Maven repo inside node_modules/react-native/.
-            // (The use of exclusiveContent prevents looking elsewhere like Maven Central
-            // and potentially getting a wrong version.)
-            filter {
-                includeGroup "com.facebook.react"
-            }
-            forRepository {
-                maven {
-                    url "$rootDir/../node_modules/react-native/android"
-                }
-            }
-        }
-        
-        mavenLocal()
-        google()
-        mavenCentral()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../node_modules/react-native/android"
-        }
-    }
-}
+// allprojects {
+//     repositories {
+//         // Ripped from https://stackoverflow.com/questions/74333787/react-native-2-files-found-with-path-lib-arm64-v8a-libfbjni-so-from-inputs
+//         exclusiveContent {
+//             // We get React Native's Android binaries exclusively through npm,
+//             // from a local Maven repo inside node_modules/react-native/.
+//             // (The use of exclusiveContent prevents looking elsewhere like Maven Central
+//             // and potentially getting a wrong version.)
+//             filter {
+//                 includeGroup "com.facebook.react"
+//             }
+//             forRepository {
+//                 maven {
+//                     url "$rootDir/../node_modules/react-native/android"
+//                 }
+//             }
+//         }
+
+//         mavenLocal()
+//         google()
+//         mavenCentral()
+//         maven {
+//             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+//             url "$rootDir/../node_modules/react-native/android"
+//         }
+//     }
+// }
 
 dependencies {
     implementation("com.facebook.react:react-native:+")
@@ -67,4 +67,4 @@ dependencies {
     implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("com.google.code.gson:gson:2.8.9")
 }
-  
+


### PR DESCRIPTION
**Requirements**

- [-] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None that I've found.

**Describe the solution you've provided**

Fix Android build issue in monorepo setup (with hoisted modules) due to a hardcoded path to node_modules in `build.gradle`

**Describe alternatives you've considered**

- My first alternative was to remove the whole `allprojects`-block since it is overriding paths that we have set in our `android/app/build.gradle` - this worked, but I'm guessing you added that fix for a reason (a reason that may now be handled: https://stackoverflow.com/questions/74333787/react-native-2-files-found-with-path-lib-arm64-v8a-libfbjni-so-from-inputs)
- Second alternative is to pass node_modules dir as config using `project.ext.launchDarkly = []` - which is non intrusive but requires config
- And then there's this option that tries to make it work out of the box without configuration but resolving the path to `node_modules`

**Additional context**

None.
