### PR TITLE
[Android] Update build.gradle for react-native 0.71.3 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,22 +35,6 @@ android {
 
 allprojects {
     repositories {
-        // Ripped from https://stackoverflow.com/questions/74333787/react-native-2-files-found-with-path-lib-arm64-v8a-libfbjni-so-from-inputs
-        exclusiveContent {
-            // We get React Native's Android binaries exclusively through npm,
-            // from a local Maven repo inside node_modules/react-native/.
-            // (The use of exclusiveContent prevents looking elsewhere like Maven Central
-            // and potentially getting a wrong version.)
-            filter {
-                includeGroup "com.facebook.react"
-            }
-            forRepository {
-                maven {
-                    url "$rootDir/../node_modules/react-native/android"
-                }
-            }
-        }
-
         mavenLocal()
         google()
         mavenCentral()


### PR DESCRIPTION
Removing workaround for maven package resolution

**Related issues**

[Please see this github issue for reference](https://github.com/facebook/react-native/issues/36234)

**Describe the solution you've provided**

I am removing local package resolution since now the native android files for react-native are hosted on maven repositories. This might break compatibility with older React Native versions, but I don't see another way around it.

