### PR TITLE
#210 - Update version import for Webpack 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 import { NativeModules, NativeEventEmitter } from 'react-native';
-import { version } from './package.json';
+import packageJson from './package.json';
 import { isContext, validateContext } from './src/contextUtils';
 import { LDInvalidUserError } from 'launchdarkly-js-sdk-common/src/errors';
 import { invalidContext } from 'launchdarkly-js-sdk-common/src/messages';
 
 let LaunchdarklyReactNativeClient = NativeModules.LaunchdarklyReactNativeClient;
+const { version } = packageJson
 
 export default class LDClient {
   constructor() {


### PR DESCRIPTION
Updated version import as webpack 5 is warning about named import.

**Requirements**

- [✔️  ] I have added test coverage for new or changed functionality
- [ ✔️ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ✔️ ] I have validated my changes against all supported platform versions

**Related issues**
#210 

**Describe the solution you've provided**
Modified version import to support webpack 5