### PR TITLE
update launchdarkly-js-sdk-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "launchdarkly-js-sdk-common": "5.0.2"
+        "launchdarkly-js-sdk-common": "5.0.3"
       },
       "devDependencies": {
         "@tsconfig/react-native": "2.0.3",
@@ -7061,9 +7061,9 @@
       }
     },
     "node_modules/launchdarkly-js-sdk-common": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.2.tgz",
-      "integrity": "sha512-fD4YndDUVWSyAFE2NdzeBSgpjPxyRN8+mz3p+VXKnDAPt3bdzGIEHrvusbY/K8fKZjpo4vRd7soNiA1EejkEPQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.3.tgz",
+      "integrity": "sha512-wKG8UsVbPVq8+7eavgAm5CVmulQWN6Ddod2ZoA3euZ1zPvJPwIQ2GrOYaCJr3cFrrMIX+nQyBJHBHYxUAPcM+Q==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "fast-deep-equal": "^2.0.1",
@@ -16173,9 +16173,9 @@
       "dev": true
     },
     "launchdarkly-js-sdk-common": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.2.tgz",
-      "integrity": "sha512-fD4YndDUVWSyAFE2NdzeBSgpjPxyRN8+mz3p+VXKnDAPt3bdzGIEHrvusbY/K8fKZjpo4vRd7soNiA1EejkEPQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.0.3.tgz",
+      "integrity": "sha512-wKG8UsVbPVq8+7eavgAm5CVmulQWN6Ddod2ZoA3euZ1zPvJPwIQ2GrOYaCJr3cFrrMIX+nQyBJHBHYxUAPcM+Q==",
       "requires": {
         "base64-js": "^1.3.0",
         "fast-deep-equal": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "homepage": "https://docs.launchdarkly.com/sdk/client-side/react-native",
   "dependencies": {
-    "launchdarkly-js-sdk-common": "5.0.2"
+    "launchdarkly-js-sdk-common": "5.0.3"
   },
   "peerDependencies": {
     "react-native": ">=0.69.0 <0.72.0"


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

- https://github.com/launchdarkly/js-sdk-common/releases/tag/5.0.3

**Describe the solution you've provided**

Updates the common SDK which includes an important type fix to make key values optional. Otherwise users are forced to either `@ts-ignore` your SDK, or provide empty string keys which crash your SDK on iOS (and potentially Android which I haven't verified)
