### PR TITLE
prepare 7.2.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
 
     macos:
       xcode: <<parameters.xcode-version>>
-    resource_class: large
 
     environment:
       ANDROID_SDK_ROOT: '/tmp/Android'

--- a/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
+++ b/android/src/main/java/com/launchdarkly/reactnative/LaunchdarklyReactNativeClientModule.java
@@ -324,7 +324,12 @@ public class LaunchdarklyReactNativeClientModule extends ReactContextBaseJavaMod
 
     private LDConfig.Builder buildConfiguration(ReadableMap config) {
         LDConfig.Builder builder = new LDConfig.Builder();
-        builder.generateAnonymousKeys(true);
+
+        if (validateConfig("generateAnonymousKeysAndroid", config, ReadableType.Boolean)) {
+            builder.generateAnonymousKeys(config.getBoolean("generateAnonymousKeysAndroid"));
+        } else {
+            builder.generateAnonymousKeys(true);
+        }
 
         // configure trivial options
         for (ConfigMapping entry : ConfigMapping.values()) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,6 +208,16 @@ declare module 'launchdarkly-react-native-client-sdk' {
      * You can also specify this on a per-context basis with {@link LDContextMeta.privateAttributes}
      */
     privateAttributes?: string[];
+
+    /**
+     * Android only.
+     *
+     * Set to true to make the SDK provide unique keys for anonymous contexts.
+     * Read more at https://launchdarkly.github.io/android-client-sdk/com/launchdarkly/sdk/android/LDConfig.Builder.html#generateAnonymousKeys(boolean).
+     *
+     * The default is true.
+     */
+    generateAnonymousKeysAndroid?: boolean;
   };
 
   /**


### PR DESCRIPTION
## [7.2.0] - 2024-03-07
### Added:
- Added Android only config option generateAnonymousKeysAndroid. This directly maps to the Android SDK config option [generateAnonymousKeys](https://launchdarkly.github.io/android-client-sdk/com/launchdarkly/sdk/android/LDConfig.Builder.html#generateAnonymousKeys(boolean)).