### PR TITLE
ci: removing private mirror from ldrelease config.yml

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -1,9 +1,5 @@
 version: 2
 
-repo:
-  public: react-native-client-sdk
-  private: react-native-client-sdk-private
-
 branches:
   - name: main
     description: 9.x


### PR DESCRIPTION
Removes the private mirror configuration for releaser.